### PR TITLE
fix: Fixes video blob error

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev:watch": "nodemon --watch dist/main.js --exec \"npm run build:release:dev\"",
     "dev:webpack": "webpack -w --env.dev",
     "build:webpack": "webpack",
-    "build:pages": "node \"src\\_langs\\metalsmith.js\"",
+    "build:pages": "node src/_langs/metalsmith.js",
     "build:bookmarklet": "node scripts/bookmarkletify.js",
     "build:bookmarklet:dev": "node scripts/bookmarkletify.js --dev",
     "build:release": "npm run build:bookmarklet && npm run build:pages",

--- a/src/helpers/getOriginalVideoFromBlob.ts
+++ b/src/helpers/getOriginalVideoFromBlob.ts
@@ -1,5 +1,5 @@
 export default function getOriginalVideoFromBlob(videoEl: HTMLVideoElement): string|null {
-  const instanceKey = Object.keys(videoEl).find(key => key.includes('Instance'))
+  const instanceKey = Object.keys(videoEl).find(key => key.includes('Instance') || key.includes('Fiber'))
   const $react = videoEl[instanceKey]
   const videoLink = $react.return.memoizedProps.fallbackSrc
 


### PR DESCRIPTION
* Fixes the `[instantgram] 4.0.5 TypeError: Cannot read properties of undefined (reading 'return')` error when using with videos
* Fixes the `Error: Cannot find module '<path>instantgram/src\_langs\metalsmith.js'` error when trying to build

NB: I did not commit my re-build of the various dist files. Will leave that to the repo owner.